### PR TITLE
Add Vision Transformer example

### DIFF
--- a/vision_transformer.py
+++ b/vision_transformer.py
@@ -1,0 +1,69 @@
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+class PatchEmbedding(nn.Module):
+    """Split image into patches and embed them."""
+
+    def __init__(self, img_size: int = 224, patch_size: int = 16, in_channels: int = 3, embed_dim: int = 768):
+        super().__init__()
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.grid_size = img_size // patch_size
+        self.num_patches = self.grid_size ** 2
+
+        self.proj = nn.Conv2d(in_channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x)  # (B, embed_dim, H/patch, W/patch)
+        x = x.flatten(2)  # (B, embed_dim, num_patches)
+        x = x.transpose(1, 2)  # (B, num_patches, embed_dim)
+        return x
+
+class VisionTransformer(nn.Module):
+    """Minimal Vision Transformer implementation."""
+
+    def __init__(self, img_size: int = 224, patch_size: int = 16, in_channels: int = 3,
+                 num_classes: int = 4, embed_dim: int = 768, depth: int = 12,
+                 num_heads: int = 12, mlp_ratio: int = 4, dropout: float = 0.1):
+        super().__init__()
+        self.patch_embed = PatchEmbedding(img_size, patch_size, in_channels, embed_dim)
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, 1 + self.patch_embed.num_patches, embed_dim))
+        self.pos_drop = nn.Dropout(dropout)
+
+        encoder_layer = nn.TransformerEncoderLayer(d_model=embed_dim, nhead=num_heads,
+                                                   dim_feedforward=embed_dim * mlp_ratio,
+                                                   dropout=dropout, activation='gelu')
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=depth)
+        self.norm = nn.LayerNorm(embed_dim)
+        self.head = nn.Linear(embed_dim, num_classes)
+        self._init_weights()
+
+    def _init_weights(self):
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+        nn.init.trunc_normal_(self.head.weight, std=0.02)
+        if self.head.bias is not None:
+            nn.init.zeros_(self.head.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B = x.size(0)
+        x = self.patch_embed(x)
+        cls_tokens = self.cls_token.expand(B, -1, -1)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x = x + self.pos_embed
+        x = self.pos_drop(x)
+
+        x = self.encoder(x)
+        x = self.norm(x)
+        cls_output = x[:, 0]
+        logits = self.head(cls_output)
+        return logits
+
+if __name__ == "__main__":
+    model = VisionTransformer(img_size=224, patch_size=16, num_classes=4)
+    dummy = torch.randn(1, 3, 224, 224)
+    out = model(dummy)
+    print(out.shape)
+


### PR DESCRIPTION
## Summary
- implement a simple Vision Transformer model in PyTorch

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: spectrum_data_models)*
- `python vision_transformer.py`

------
https://chatgpt.com/codex/tasks/task_e_685e0cedd26c832a856c63ce0b6ece7d